### PR TITLE
Taggers pool

### DIFF
--- a/deep_disfluency/tagger/pool.py
+++ b/deep_disfluency/tagger/pool.py
@@ -1,0 +1,47 @@
+"""
+Taggers initialisation is expensive. Having a pool of taggers instantiated in
+parallel make checking out and in fast. It's up to the client to make sure not
+to exhaust the pool.
+"""
+import threading
+
+
+class Pool(object):
+    def __init__(self, pool_size, tagger_class, init_args=(), init_kwargs=None):
+        """Instantiate the pool and its taggers."""
+
+        if init_kwargs is None:
+            init_kwargs = {}
+
+        self.pool_size = pool_size
+        self.tagger_class = tagger_class
+        self.init_args = init_args
+        self.init_kwargs = init_kwargs
+
+        self._pool = set()
+        self._pool_lock = threading.Lock()
+
+        # We can do it with threads because the taggers are already parallelized
+        init_threads = []
+        for _ in range(self.pool_size):
+            t = threading.Thread(target=self._init_instance)
+            t.start()
+            init_threads.append(t)
+        for t in init_threads:
+            t.join()
+
+    def _init_instance(self):
+        instance = self.tagger_class(*self.init_args, **self.init_kwargs)
+        with self._pool_lock:
+            self._pool.add(instance)
+
+    def checkout(self):
+        """Get a tagger from the pool."""
+        with self._pool_lock:
+            return self._pool.pop()
+
+    def checkin(self, tagger):
+        """Return a tagger to the pool"""
+        tagger.reset()
+        with self._pool_lock:
+            self._pool.add(tagger)

--- a/test/test_pool.py
+++ b/test/test_pool.py
@@ -1,0 +1,52 @@
+import time
+import unittest
+
+from deep_disfluency.tagger.pool import Pool
+
+
+class FakeSlowInitTagger(object):
+    def __init__(self):
+        time.sleep(0.1)
+
+
+class FakeInitTagger(object):
+    def __init__(self):
+        self.reset_called = False
+
+    def reset(self):
+        self.reset_called = True
+
+
+class TestPool(unittest.TestCase):
+
+    def test_pool_parallelism(self):
+        start = time.time()
+        Pool(pool_size=10, tagger_class=FakeSlowInitTagger)
+        end = time.time()
+        # 10 parallel instantiates, each takes 0.1 sec, should take less than 0.2
+        # secs.
+        self.assertLess(end - start, 0.2)
+
+    def test_checkout(self):
+        p = Pool(pool_size=2, tagger_class=FakeInitTagger)
+        tagger = p.checkout()
+        self.assertIsInstance(tagger, FakeInitTagger)
+        self.assertEqual(len(p._pool), 1)
+
+    def test_checkin_returns_to_pool(self):
+        p = Pool(pool_size=2, tagger_class=FakeInitTagger)
+        tagger = p.checkout()
+        self.assertEqual(len(p._pool), 1)
+        p.checkin(tagger)
+        self.assertEqual(len(p._pool), 2)
+
+    def test_checkin_resets(self):
+        p = Pool(pool_size=2, tagger_class=FakeInitTagger)
+        tagger = p.checkout()
+        self.assertFalse(tagger.reset_called)
+        p.checkin(tagger)
+        self.assertTrue(tagger.reset_called)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is some infrastrucutre for a TCP disfluency tagger server I'm working on. Yet, it's completely standalone so might worth a separate PR. Instantiating  a tagger is a slow operation. Here, a pool of taggers are instantiated together, in separate threads. Then, clients can checkout taggers, and check them in after they finish.