### PR TITLE
TCP server

### DIFF
--- a/asr_tcp_client_demo.py
+++ b/asr_tcp_client_demo.py
@@ -1,0 +1,41 @@
+"""
+A TCP client that listen to the computer sound card (e.g. microphone),
+sends raw audio samples to a TCP server (implemented in
+`asr_tcp_server_demo.py`) and receives disfluency tags.
+"""
+from __future__ import print_function
+
+import socket
+import threading
+
+import sounddevice
+
+HOST = '127.0.0.1'
+PORT = 50007
+AUDIO_OPTS = {
+    'dtype': 'int16',
+    'samplerate': 44100,
+    'channels': 1,
+}
+BUFFER_SIZE = 2048
+
+
+def tcp_receiver(sock):
+    print('Receiving...')
+    while True:
+        print(sock.recv(1024), end='')
+
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.connect((HOST, PORT))
+print('Connected')
+
+t = threading.Thread(target=tcp_receiver, args=(sock, ))
+t.daemon = True
+t.start()
+
+with sounddevice.RawInputStream(**AUDIO_OPTS) as stream:
+    while True:
+        chunk, _ = stream.read(BUFFER_SIZE)
+        sock.sendall(chunk[:])
+s.close()

--- a/asr_tcp_server_demo.py
+++ b/asr_tcp_server_demo.py
@@ -1,0 +1,123 @@
+"""
+A TCP server that receives raw audio and reply with disfluency tags.
+"""
+from __future__ import print_function
+
+import socket
+import threading
+
+from deep_disfluency.asr.ibm_watson import IBMWatsonASR
+from deep_disfluency.tagger.deep_tagger import DeepDisfluencyTagger
+from deep_disfluency.tagger.pool import Pool
+import watson_streaming
+
+HOST = ''  # Symbolic name meaning all available interfaces
+PORT = 50007  # Arbitrary non-privileged port
+TCP_INPUT_BUFFER_SIZE = 1024  # Number of bytes to read from TCP socket
+POOL_SIZE = 4  # How many taggers to instantiate
+TAGGER_SETTINGS = {
+    'config_file': 'deep_disfluency/experiments/experiment_configs.csv',
+    'config_number': 35,
+    'saved_model_dir': 'deep_disfluency/experiments/035/epoch_6',
+    'use_timing_data': True,
+}
+WATSON_SETTINGS = {
+    'inactivity_timeout': -1,  # Don't kill me after 30 seconds
+    'interim_results': True,
+    'timestamps': True
+}
+
+
+class TranscribeAdapter(object):
+    """
+    An adapter between a TCP connection, IBM Watson, and a disfluency tagger.
+    It exposes `audio_gen` and `callback` methods to use with
+    `watson_streaming.transcribe`.
+    """
+
+    def __init__(self, conn, tagger, input_buffer_size):
+        self.conn = conn
+        self.disf = tagger
+        self.input_buffer_size = input_buffer_size
+        self.asr = IBMWatsonASR(new_hypothesis_callback=self._new_word_hypotheses_handler)
+
+    def audio_gen(self):
+        """
+        Generates raw audio samples from data received from the TCP connection.
+        """
+        while True:
+            yield self.conn.recv(self.input_buffer_size)
+
+    def callback(self, data):
+        """
+        Sends disfluency analysis over TCP connection.
+        """
+        return self.asr.callback(data)
+
+    def _new_word_hypotheses_handler(self, word_diff, rollback, word_graph):
+        """
+        Define what you want to happen when new word hypotheses come in.
+        Based on `asr_demo.py`.
+        """
+        if word_diff == []:
+            return
+        self.disf.rollback(rollback)
+        last_end_time = 0
+        if len(word_graph) > 1:
+            last_end_time = word_graph[(len(word_graph)-len(word_diff))-1][-1]
+        # tag new words and work out where the new tuples start
+        new_output_start = max([0, len(self.disf.get_output_tags())-1])
+        for word, _, end_time in word_diff:
+            timing = end_time - last_end_time
+            new_tags = self.disf.tag_new_word(word, timing=timing)
+            start_test = max([0, len(self.disf.get_output_tags())-len(new_tags)-1])
+            if start_test < new_output_start:
+                new_output_start = start_test
+            last_end_time = end_time
+        # Send out all the output tags from the new word diff onwards
+        for w, h in zip(
+                word_graph[new_output_start:],
+                self.disf.get_output_tags(with_words=False)[new_output_start:]):
+            self.conn.sendall("{},{},{},{}\n".format(w[0], w[1], w[2], h))
+
+
+class TCPHandler(threading.Thread):
+    def __init__(self, conn, pool):
+        super(TCPHandler, self).__init__()
+        self.conn = conn
+        self.pool = pool
+        self.daemon = True
+
+    def run(self):
+        tagger = self.pool.checkout()
+        try:
+            adapter = TranscribeAdapter(self.conn, tagger, TCP_INPUT_BUFFER_SIZE)
+            watson_streaming.transcribe(
+                adapter.callback,
+                WATSON_SETTINGS,
+                "credentials.json",
+                adapter.audio_gen,
+            )
+        finally:
+            self.pool.checkin(tagger)
+
+
+def main():
+    pool = Pool(pool_size=POOL_SIZE, tagger_class=DeepDisfluencyTagger,
+                init_kwargs=TAGGER_SETTINGS)
+    print('Taggers pool ready')
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind((HOST, PORT))
+    sock.listen(1)
+    print('Server listening')
+
+    while True:
+        conn, addr = sock.accept()
+        print('Connected by', addr)
+        handler = TCPHandler(conn, pool)
+        handler.start()
+
+
+if __name__ == '__main__':
+    main()

--- a/deep_disfluency/asr/ibm_watson.py
+++ b/deep_disfluency/asr/ibm_watson.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 class IBMWatsonASR(ASR):
 
-    def __init__(self, credentials_file, new_hypothesis_callback=None,
+    def __init__(self, credentials_file=None, new_hypothesis_callback=None,
                  settings=None):
         ASR.__init__(self, credentials_file,  new_hypothesis_callback,
                      settings)

--- a/deep_disfluency/tagger/pool.py
+++ b/deep_disfluency/tagger/pool.py
@@ -1,0 +1,47 @@
+"""
+Taggers initialisation is expensive. Having a pool of taggers instantiated in
+parallel make checking out and in fast. It's up to the client to make sure not
+to exhaust the pool.
+"""
+import threading
+
+
+class Pool(object):
+    def __init__(self, pool_size, tagger_class, init_args=(), init_kwargs=None):
+        """Instantiate the pool and its taggers."""
+
+        if init_kwargs is None:
+            init_kwargs = {}
+
+        self.pool_size = pool_size
+        self.tagger_class = tagger_class
+        self.init_args = init_args
+        self.init_kwargs = init_kwargs
+
+        self._pool = set()
+        self._pool_lock = threading.Lock()
+
+        # We can do it with threads because the taggers are already parallelized
+        init_threads = []
+        for _ in range(self.pool_size):
+            t = threading.Thread(target=self._init_instance)
+            t.start()
+            init_threads.append(t)
+        for t in init_threads:
+            t.join()
+
+    def _init_instance(self):
+        instance = self.tagger_class(*self.init_args, **self.init_kwargs)
+        with self._pool_lock:
+            self._pool.add(instance)
+
+    def checkout(self):
+        """Get a tagger from the pool."""
+        with self._pool_lock:
+            return self._pool.pop()
+
+    def checkin(self, tagger):
+        """Return a tagger to the pool"""
+        tagger.reset()
+        with self._pool_lock:
+            self._pool.add(tagger)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ boto3==1.5.34
 botocore==1.8.48
 bz2file==0.98
 certifi==2018.1.18
-cffi==1.11.4
+cffi==1.11.5
 chardet==3.0.4
 configparser==3.5.0
 cycler==0.10.0
@@ -77,7 +77,7 @@ Theano==0.9.0
 tornado==4.5.3
 traitlets==4.3.2
 urllib3==1.22
-watson-streaming==0.0.4
+watson-streaming==0.0.5
 wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.47.0

--- a/test/test_pool.py
+++ b/test/test_pool.py
@@ -1,0 +1,52 @@
+import time
+import unittest
+
+from deep_disfluency.tagger.pool import Pool
+
+
+class FakeSlowInitTagger(object):
+    def __init__(self):
+        time.sleep(0.1)
+
+
+class FakeInitTagger(object):
+    def __init__(self):
+        self.reset_called = False
+
+    def reset(self):
+        self.reset_called = True
+
+
+class TestPool(unittest.TestCase):
+
+    def test_pool_parallelism(self):
+        start = time.time()
+        Pool(pool_size=10, tagger_class=FakeSlowInitTagger)
+        end = time.time()
+        # 10 parallel instantiates, each takes 0.1 sec, should take less than 0.2
+        # secs.
+        self.assertLess(end - start, 0.2)
+
+    def test_checkout(self):
+        p = Pool(pool_size=2, tagger_class=FakeInitTagger)
+        tagger = p.checkout()
+        self.assertIsInstance(tagger, FakeInitTagger)
+        self.assertEqual(len(p._pool), 1)
+
+    def test_checkin_returns_to_pool(self):
+        p = Pool(pool_size=2, tagger_class=FakeInitTagger)
+        tagger = p.checkout()
+        self.assertEqual(len(p._pool), 1)
+        p.checkin(tagger)
+        self.assertEqual(len(p._pool), 2)
+
+    def test_checkin_resets(self):
+        p = Pool(pool_size=2, tagger_class=FakeInitTagger)
+        tagger = p.checkout()
+        self.assertFalse(tagger.reset_called)
+        p.checkin(tagger)
+        self.assertTrue(tagger.reset_called)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
If you exclude the taggers pool instroduced in PR #8, this PR contributes a demo of a disfluency tagging TCP server and client in `asr_tcp_server_demo.py` and `asr_tcp_client_demo.py`. The idea is similar to the `asr_demo.py`, but instead of getting the audio directly from the sound card, it is received over TCP. This allows new configurations and the ability to integrate the deep disfluency tagger into projects in other languages.

Will be happy to discuss the design decisions further and help improving this PR and the surrounding code (especially the somewhat messy `new_word_hypotheses_handler`).