### PR TITLE
Windows filenames shouldn't contain question marks

### DIFF
--- a/deep_disfluency/experiments/EACL_2017.py
+++ b/deep_disfluency/experiments/EACL_2017.py
@@ -63,7 +63,7 @@ experiments = [33, 34, 35, 36, 37, 38]
 # experiments = [35]  # short version for testing
 # 1. Download the SWDA and word timings
 if download_raw_data:
-    name = THIS_DIR + '/../data/raw_data/' + SWDA_CORPUS_URL.split('/')[-1]
+    name = THIS_DIR + '/../data/raw_data/swda.zip'
     if not os.path.isfile(name):
         print 'downloading', name
         urllib.urlretrieve(SWDA_CORPUS_URL, name)

--- a/deep_disfluency/experiments/InterSpeech_2015.py
+++ b/deep_disfluency/experiments/InterSpeech_2015.py
@@ -61,7 +61,7 @@ experiments = [21, 41]  # reduced version for speed for now
 
 # 1. download the data
 if download_raw_data:
-    name = THIS_DIR + '/../data/raw_data/' + SWDA_CORPUS_URL.split('/')[-1]
+    name = THIS_DIR + '/../data/raw_data/swda.zip'
     if not os.path.isfile(name):
         print 'downloading', name
         urllib.urlretrieve(SWDA_CORPUS_URL, name)


### PR DESCRIPTION
It was impossible to even clone the repo on windows due to `swda.zip?raw=true`. Should be better now. 