### PR TITLE
Mark pickle files as binaries in .gitattributes so they won't convert to dos files on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pkl binary


### PR DESCRIPTION
This solves the issue of failing to unpickle.